### PR TITLE
Gjoel004

### DIFF
--- a/src/main/java/ch/ethz/idsc/gokart/core/pure/CurveGeodesicPursuitHelper.java
+++ b/src/main/java/ch/ethz/idsc/gokart/core/pure/CurveGeodesicPursuitHelper.java
@@ -13,12 +13,14 @@ import ch.ethz.idsc.owl.math.planar.Extract2D;
 import ch.ethz.idsc.owl.math.planar.GeodesicPursuit;
 import ch.ethz.idsc.owl.math.planar.GeodesicPursuitInterface;
 import ch.ethz.idsc.owl.math.planar.TrajectoryEntryFinder;
+import ch.ethz.idsc.retina.util.math.SI;
 import ch.ethz.idsc.sophus.group.Se2GroupElement;
 import ch.ethz.idsc.sophus.math.GeodesicInterface;
 import ch.ethz.idsc.tensor.RealScalar;
 import ch.ethz.idsc.tensor.Scalar;
 import ch.ethz.idsc.tensor.Tensor;
 import ch.ethz.idsc.tensor.opt.TensorUnaryOperator;
+import ch.ethz.idsc.tensor.qty.Quantity;
 import ch.ethz.idsc.tensor.red.Norm;
 
 /* package */ enum CurveGeodesicPursuitHelper {
@@ -30,7 +32,7 @@ import ch.ethz.idsc.tensor.red.Norm;
    * @param geodesicInterface type of planned curve
    * @param trajectoryEntryFinder strategy to find best re-entry point
    * @param ratioLimits depending on pose and speed
-   * @return ratio rate unitless but with interpretation rad*m^-1 */
+   * @return ratio rate [rad*m^-1] */
   static Optional<Scalar> getRatio( //
       Tensor pose, Scalar speed, Tensor curve, boolean isForward, //
       GeodesicInterface geodesicInterface, //
@@ -50,7 +52,7 @@ import ch.ethz.idsc.tensor.red.Norm;
     };
     Scalar var = ArgMinVariable.using(trajectoryEntryFinder, mapping, 25).apply(tensor);
     Optional<Tensor> lookAhead = trajectoryEntryFinder.on(tensor).apply(var).point;
-    return lookAhead.map(vector -> new GeodesicPursuit(geodesicInterface, vector).firstRatio().orElse(null));
+    return lookAhead.map(vector -> new GeodesicPursuit(geodesicInterface, vector).firstRatio().map(r -> Quantity.of(r, SI.PER_METER)).orElse(null));
   }
 
   /** mirror the points along the y axis and invert their orientation

--- a/src/main/java/ch/ethz/idsc/gokart/core/pure/CurveGeodesicPursuitHelper.java
+++ b/src/main/java/ch/ethz/idsc/gokart/core/pure/CurveGeodesicPursuitHelper.java
@@ -45,7 +45,7 @@ import ch.ethz.idsc.tensor.red.Norm;
     Predicate<Scalar> isCompliant = isCompliant(ratioLimits, pose, speed);
     Function<Tensor, Scalar> mapping = vector -> { //
       GeodesicPursuitInterface geodesicPursuit = new GeodesicPursuit(geodesicInterface, vector);
-      Tensor ratios = geodesicPursuit.ratios();
+      Tensor ratios = geodesicPursuit.ratios().map(r -> Quantity.of(r, SI.PER_METER));
       if (ratios.stream().map(Tensor::Get).allMatch(isCompliant))
         return Norm._2.ofVector(Extract2D.FUNCTION.apply(vector));
       return RealScalar.of(Double.MAX_VALUE); // TODO GJOEL unitless?

--- a/src/main/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitHelper.java
+++ b/src/main/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitHelper.java
@@ -6,10 +6,12 @@ import java.util.Optional;
 import ch.ethz.idsc.gokart.core.pos.GokartPoseHelper;
 import ch.ethz.idsc.owl.math.map.Se2Bijection;
 import ch.ethz.idsc.owl.math.planar.PurePursuit;
+import ch.ethz.idsc.retina.util.math.SI;
 import ch.ethz.idsc.tensor.Scalar;
 import ch.ethz.idsc.tensor.Tensor;
 import ch.ethz.idsc.tensor.alg.Reverse;
 import ch.ethz.idsc.tensor.opt.TensorUnaryOperator;
+import ch.ethz.idsc.tensor.qty.Quantity;
 
 /* package */ enum CurvePurePursuitHelper {
   ;
@@ -17,7 +19,7 @@ import ch.ethz.idsc.tensor.opt.TensorUnaryOperator;
    * @param curve in world coordinates
    * @param isForward driving direction, true when forward or stopped, false when driving backwards
    * @param distance for instance PursuitConfig.GLOBAL.lookAheadMeter()
-   * @return ratio rate with interpretation rad*m^-1 */
+   * @return ratio rate [rad*m^-1] */
   static Optional<Scalar> getRatio(Tensor pose, Tensor curve, boolean isForward, Scalar distance) {
     return getRatio(pose, curve, true, isForward, distance);
   }
@@ -32,7 +34,7 @@ import ch.ethz.idsc.tensor.opt.TensorUnaryOperator;
     Optional<Tensor> aheadTrail = CurveUtils.getAheadTrail(tensor, distance);
     if (aheadTrail.isPresent()) {
       PurePursuit purePursuit = PurePursuit.fromTrajectory(aheadTrail.get(), distance);
-      return purePursuit.ratio();
+      return purePursuit.ratio().map(r -> Quantity.of(r, SI.PER_METER));
     }
     return Optional.empty();
   }

--- a/src/main/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitModule.java
+++ b/src/main/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitModule.java
@@ -67,7 +67,7 @@ public class CurvePurePursuitModule extends PurePursuitModule implements GokartP
       final Scalar quality = gokartPoseEvent.getQuality();
       if (LocalizationConfig.GLOBAL.isQualityOk(quality)) { // is localization quality sufficient?
         Tensor pose = gokartPoseEvent.getPose(); // latest pose
-        Optional<Scalar> ratio = getRatio(pose).map(Magnitude.PER_METER);
+        Optional<Scalar> ratio = getRatio(pose);
         if (ratio.isPresent()) { // is look ahead beacon available?
           Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(ratio.get());
           if (angleClip.isInside(angle)) // is look ahead beacon within steering range?

--- a/src/main/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitModule.java
+++ b/src/main/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitModule.java
@@ -13,6 +13,7 @@ import ch.ethz.idsc.gokart.dev.rimo.RimoGetEvent;
 import ch.ethz.idsc.gokart.dev.rimo.RimoGetListener;
 import ch.ethz.idsc.gokart.dev.rimo.RimoSocket;
 import ch.ethz.idsc.gokart.gui.top.ChassisGeometry;
+import ch.ethz.idsc.retina.util.math.Magnitude;
 import ch.ethz.idsc.retina.util.math.SI;
 import ch.ethz.idsc.tensor.Scalar;
 import ch.ethz.idsc.tensor.Tensor;
@@ -66,7 +67,7 @@ public class CurvePurePursuitModule extends PurePursuitModule implements GokartP
       final Scalar quality = gokartPoseEvent.getQuality();
       if (LocalizationConfig.GLOBAL.isQualityOk(quality)) { // is localization quality sufficient?
         Tensor pose = gokartPoseEvent.getPose(); // latest pose
-        Optional<Scalar> ratio = getRatio(pose);
+        Optional<Scalar> ratio = getRatio(pose).map(Magnitude.PER_METER);
         if (ratio.isPresent()) { // is look ahead beacon available?
           Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(ratio.get());
           if (angleClip.isInside(angle)) // is look ahead beacon within steering range?
@@ -79,10 +80,9 @@ public class CurvePurePursuitModule extends PurePursuitModule implements GokartP
     return Optional.empty(); // autonomous operation denied
   }
 
-  // TODO JPH function should return a scalar with unit "m^-1"...
-  // right now, "curve" does not have "m" as unit but entries are unitless.
-  /** @param pose
-   * @return */
+  // TODO JPH right now, "curve" does not have "m" as unit but entries are unitless.
+  /** @param pose of vehicle {x[m], y[m], angle}
+   * @return ratio rate [rad*m^-1] */
   protected synchronized Optional<Scalar> getRatio(Tensor pose) {
     Optional<Tensor> optionalCurve = this.optionalCurve; // copy reference instead of synchronize
     if (optionalCurve.isPresent())

--- a/src/main/java/ch/ethz/idsc/gokart/core/pure/PursuitConfig.java
+++ b/src/main/java/ch/ethz/idsc/gokart/core/pure/PursuitConfig.java
@@ -45,9 +45,7 @@ public class PursuitConfig {
 
   // ---
   public static final List<DynamicRatioLimit> ratioLimits() {
-    // TODO GJOEL don't remove unit m^-1
-    return Collections.singletonList(new StaticRatioLimit( //
-        Magnitude.PER_METER.apply(SteerConfig.GLOBAL.turningRatioMax)));
+    return Collections.singletonList(new StaticRatioLimit(SteerConfig.GLOBAL.turningRatioMax));
   }
 
   /***************************************************/

--- a/src/main/java/ch/ethz/idsc/gokart/core/pure/SlamCurvePurePursuitModule.java
+++ b/src/main/java/ch/ethz/idsc/gokart/core/pure/SlamCurvePurePursuitModule.java
@@ -6,8 +6,10 @@ import java.util.Optional;
 import ch.ethz.idsc.demo.mg.slam.config.SlamDvsConfig;
 import ch.ethz.idsc.gokart.gui.top.ChassisGeometry;
 import ch.ethz.idsc.owl.math.planar.PurePursuit;
+import ch.ethz.idsc.retina.util.math.SI;
 import ch.ethz.idsc.tensor.Scalar;
 import ch.ethz.idsc.tensor.Tensor;
+import ch.ethz.idsc.tensor.qty.Quantity;
 
 /** pure pursuit controller for SLAM algorithm */
 // XXX MG when only forward driving is supported, the speed should be Ramp'ed
@@ -43,12 +45,9 @@ public final class SlamCurvePurePursuitModule extends PurePursuitModule {
   private Optional<Scalar> getRatio() {
     Optional<Tensor> optionalCurve = this.optionalCurve; // copy reference instead of synchronize
     if (optionalCurve.isPresent()) {
-      if (optionalCurve.isPresent()) {
-        PurePursuit purePursuit = PurePursuit.fromTrajectory( //
-            optionalCurve.get(), SlamDvsConfig.eventCamera.slamPrcConfig.lookAheadMeter());
-        return purePursuit.ratio();
-      }
-      return Optional.empty();
+      PurePursuit purePursuit = PurePursuit.fromTrajectory( //
+          optionalCurve.get(), SlamDvsConfig.eventCamera.slamPrcConfig.lookAheadMeter());
+      return purePursuit.ratio().map(r -> Quantity.of(r, SI.PER_METER));
     }
     System.err.println("no curve in pure pursuit");
     return Optional.empty();

--- a/src/main/java/ch/ethz/idsc/gokart/gui/top/ChassisGeometry.java
+++ b/src/main/java/ch/ethz/idsc/gokart/gui/top/ChassisGeometry.java
@@ -77,12 +77,11 @@ public class ChassisGeometry {
 
   /** function ArcTan[d * r] approx. d * r for d ~ 1 and small r
    * inverse function of {@link TurningGeometry}
-   * @param ratio without unit but with interpretation "m^-1"
+   * @param ratio [m^-1]
    * see for instance SteerConfig.GLOBAL.turningRatioMax
    * @return steering angle unitless */
   public Scalar steerAngleForTurningRatio(Scalar ratio) {
-    // TODO JPH require ratio to have unit "m^-1"
-    return ArcTan.of(xAxleDistanceMeter().multiply(ratio));
+    return ArcTan.of(xAxleRtoF.multiply(ratio));
   }
 
   /** @param rimoGetEvent

--- a/src/test/java/ch/ethz/idsc/gokart/core/pure/CurveGeodesicPursuitHelperTest.java
+++ b/src/test/java/ch/ethz/idsc/gokart/core/pure/CurveGeodesicPursuitHelperTest.java
@@ -24,7 +24,7 @@ public class CurveGeodesicPursuitHelperTest extends TestCase {
     Optional<Scalar> optional = CurveGeodesicPursuitHelper.getRatio(pose, speed, DubendorfCurve.TRACK_OVAL_SE2, true, //
         PursuitConfig.GLOBAL.geodesicInterface, PursuitConfig.GLOBAL.trajectoryEntryFinder, PursuitConfig.ratioLimits());
     Scalar ratio = optional.get();
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Magnitude.PER_METER.apply(ratio));
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(ratio);
     assertTrue(Clips.interval( //
         Quantity.of(-0.38, ""), //
         Quantity.of(-0.37, "")).isInside(angle));
@@ -36,7 +36,7 @@ public class CurveGeodesicPursuitHelperTest extends TestCase {
     Optional<Scalar> optional = CurveGeodesicPursuitHelper.getRatio(pose, speed, DubendorfCurve.TRACK_OVAL_SE2, true, //
         PursuitConfig.GLOBAL.geodesicInterface, PursuitConfig.GLOBAL.trajectoryEntryFinder, PursuitConfig.ratioLimits());
     Scalar ratio = optional.get();
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Magnitude.PER_METER.apply(ratio));
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(ratio);
     assertTrue(Clips.interval( //
         Quantity.of(-0.37, ""), //
         Quantity.of(-0.36, "")).isInside(angle));

--- a/src/test/java/ch/ethz/idsc/gokart/core/pure/CurveGeodesicPursuitHelperTest.java
+++ b/src/test/java/ch/ethz/idsc/gokart/core/pure/CurveGeodesicPursuitHelperTest.java
@@ -4,6 +4,7 @@ package ch.ethz.idsc.gokart.core.pure;
 import java.util.Optional;
 
 import ch.ethz.idsc.gokart.gui.top.ChassisGeometry;
+import ch.ethz.idsc.retina.util.math.Magnitude;
 import ch.ethz.idsc.retina.util.math.SI;
 import ch.ethz.idsc.sophus.group.Se2GroupElement;
 import ch.ethz.idsc.tensor.Scalar;
@@ -23,7 +24,7 @@ public class CurveGeodesicPursuitHelperTest extends TestCase {
     Optional<Scalar> optional = CurveGeodesicPursuitHelper.getRatio(pose, speed, DubendorfCurve.TRACK_OVAL_SE2, true, //
         PursuitConfig.GLOBAL.geodesicInterface, PursuitConfig.GLOBAL.trajectoryEntryFinder, PursuitConfig.ratioLimits());
     Scalar ratio = optional.get();
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(ratio);
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Magnitude.PER_METER.apply(ratio));
     assertTrue(Clips.interval( //
         Quantity.of(-0.38, ""), //
         Quantity.of(-0.37, "")).isInside(angle));
@@ -35,7 +36,7 @@ public class CurveGeodesicPursuitHelperTest extends TestCase {
     Optional<Scalar> optional = CurveGeodesicPursuitHelper.getRatio(pose, speed, DubendorfCurve.TRACK_OVAL_SE2, true, //
         PursuitConfig.GLOBAL.geodesicInterface, PursuitConfig.GLOBAL.trajectoryEntryFinder, PursuitConfig.ratioLimits());
     Scalar ratio = optional.get();
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(ratio);
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Magnitude.PER_METER.apply(ratio));
     assertTrue(Clips.interval( //
         Quantity.of(-0.37, ""), //
         Quantity.of(-0.36, "")).isInside(angle));

--- a/src/test/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitHelperTest.java
+++ b/src/test/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitHelperTest.java
@@ -4,6 +4,8 @@ package ch.ethz.idsc.gokart.core.pure;
 import java.util.Optional;
 
 import ch.ethz.idsc.gokart.gui.top.ChassisGeometry;
+import ch.ethz.idsc.retina.util.math.Magnitude;
+import ch.ethz.idsc.retina.util.math.SI;
 import ch.ethz.idsc.tensor.Scalar;
 import ch.ethz.idsc.tensor.Tensor;
 import ch.ethz.idsc.tensor.Tensors;
@@ -16,7 +18,7 @@ public class CurvePurePursuitHelperTest extends TestCase {
     Tensor pose = Tensors.fromString("{35.1[m], 44.9[m], 1}");
     Optional<Scalar> optional = CurvePurePursuitHelper.getRatio(pose, DubendorfCurve.OVAL, true, PursuitConfig.GLOBAL.lookAheadMeter());
     Scalar lookAhead = optional.get();
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(lookAhead);
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Magnitude.PER_METER.apply(lookAhead));
     // assertTrue(Clip.function( // for look ahead 3.9[m]
     // Quantity.of(-0.018, ""), //
     // Quantity.of(-0.016, "")).isInside(angle));
@@ -29,7 +31,7 @@ public class CurvePurePursuitHelperTest extends TestCase {
     Tensor pose = Tensors.fromString("{35.1[m], 44.9[m], 0.9}");
     Optional<Scalar> optional = CurvePurePursuitHelper.getRatio(pose, DubendorfCurve.OVAL, true, PursuitConfig.GLOBAL.lookAheadMeter());
     Scalar lookAhead = optional.get();
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(lookAhead);
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Magnitude.PER_METER.apply(lookAhead));
     assertTrue(Clips.interval( //
         Quantity.of(0.04, ""), //
         Quantity.of(0.07, "")).isInside(angle));
@@ -51,27 +53,27 @@ public class CurvePurePursuitHelperTest extends TestCase {
     Tensor pose = Tensors.fromString("{50.0[m], 48.6[m], 0.0}");
     Optional<Scalar> optional = CurvePurePursuitHelper.getRatio(pose, DubendorfCurve.HYPERLOOP_EIGHT, true, PursuitConfig.GLOBAL.lookAheadMeter());
     Scalar lookAhead = optional.get();
-    Clips.interval(0.062, 0.069).requireInside(lookAhead);
+    Clips.interval(Quantity.of(0.062, SI.PER_METER), Quantity.of(0.069, SI.PER_METER)).requireInside(lookAhead);
   }
 
   public void testSpecificHLE_R() throws Exception {
     Tensor pose = Tensors.fromString("{50.0[m], 48.6[m], 0.0}");
     Optional<Scalar> optional = CurvePurePursuitHelper.getRatio(pose, DubendorfCurve.HYPERLOOP_EIGHT, false, PursuitConfig.GLOBAL.lookAheadMeter());
     Scalar lookAhead = optional.get();
-    Clips.interval(0.0096, 0.015).requireInside(lookAhead);
+    Clips.interval(Quantity.of(0.0096, SI.PER_METER), Quantity.of(0.015, SI.PER_METER)).requireInside(lookAhead);
   }
 
   public void testSpecificHLER() throws Exception {
     Tensor pose = Tensors.fromString("{50.0[m], 48.6[m], 3.1415926535897932385}");
     Optional<Scalar> optional = CurvePurePursuitHelper.getRatio(pose, DubendorfCurve.HYPERLOOP_EIGHT_REVERSE, true, PursuitConfig.GLOBAL.lookAheadMeter());
     Scalar lookAhead = optional.get();
-    Clips.interval(-0.015, -0.0096).requireInside(lookAhead);
+    Clips.interval(Quantity.of(-0.015, SI.PER_METER), Quantity.of(-0.0096, SI.PER_METER)).requireInside(lookAhead);
   }
 
   public void testSpecificHLER_R() throws Exception {
     Tensor pose = Tensors.fromString("{50.0[m], 48.6[m], 3.1415926535897932385}");
     Optional<Scalar> optional = CurvePurePursuitHelper.getRatio(pose, DubendorfCurve.HYPERLOOP_EIGHT_REVERSE, false, PursuitConfig.GLOBAL.lookAheadMeter());
     Scalar lookAhead = optional.get();
-    Clips.interval(-0.069, -0.062).requireInside(lookAhead);
+    Clips.interval(Quantity.of(-0.069, SI.PER_METER), Quantity.of(-0.062, SI.PER_METER)).requireInside(lookAhead);
   }
 }

--- a/src/test/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitHelperTest.java
+++ b/src/test/java/ch/ethz/idsc/gokart/core/pure/CurvePurePursuitHelperTest.java
@@ -18,7 +18,7 @@ public class CurvePurePursuitHelperTest extends TestCase {
     Tensor pose = Tensors.fromString("{35.1[m], 44.9[m], 1}");
     Optional<Scalar> optional = CurvePurePursuitHelper.getRatio(pose, DubendorfCurve.OVAL, true, PursuitConfig.GLOBAL.lookAheadMeter());
     Scalar lookAhead = optional.get();
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Magnitude.PER_METER.apply(lookAhead));
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(lookAhead);
     // assertTrue(Clip.function( // for look ahead 3.9[m]
     // Quantity.of(-0.018, ""), //
     // Quantity.of(-0.016, "")).isInside(angle));
@@ -31,7 +31,7 @@ public class CurvePurePursuitHelperTest extends TestCase {
     Tensor pose = Tensors.fromString("{35.1[m], 44.9[m], 0.9}");
     Optional<Scalar> optional = CurvePurePursuitHelper.getRatio(pose, DubendorfCurve.OVAL, true, PursuitConfig.GLOBAL.lookAheadMeter());
     Scalar lookAhead = optional.get();
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Magnitude.PER_METER.apply(lookAhead));
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(lookAhead);
     assertTrue(Clips.interval( //
         Quantity.of(0.04, ""), //
         Quantity.of(0.07, "")).isInside(angle));

--- a/src/test/java/ch/ethz/idsc/gokart/dev/steer/SteerConfigTest.java
+++ b/src/test/java/ch/ethz/idsc/gokart/dev/steer/SteerConfigTest.java
@@ -48,8 +48,7 @@ public class SteerConfigTest extends TestCase {
 
   public void testTurningAtLimit() {
     // according to our model
-    Scalar ratio_unitless = Magnitude.PER_METER.apply(SteerConfig.GLOBAL.turningRatioMax);
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(ratio_unitless);
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(SteerConfig.GLOBAL.turningRatioMax);
     // angle == 0.4521892315592385[rad]
     SteerMapping steerMapping = SteerConfig.GLOBAL.getSteerMapping();
     Scalar encoder = steerMapping.getSCEfromAngle(angle);

--- a/src/test/java/ch/ethz/idsc/gokart/gui/top/ChassisGeometryTest.java
+++ b/src/test/java/ch/ethz/idsc/gokart/gui/top/ChassisGeometryTest.java
@@ -6,11 +6,13 @@ import ch.ethz.idsc.gokart.dev.rimo.RimoGetEvent;
 import ch.ethz.idsc.gokart.dev.rimo.RimoGetEvents;
 import ch.ethz.idsc.owl.car.math.DifferentialSpeed;
 import ch.ethz.idsc.retina.util.math.Magnitude;
+import ch.ethz.idsc.retina.util.math.SI;
 import ch.ethz.idsc.tensor.DoubleScalar;
 import ch.ethz.idsc.tensor.RealScalar;
 import ch.ethz.idsc.tensor.Scalar;
 import ch.ethz.idsc.tensor.Tensor;
 import ch.ethz.idsc.tensor.Tensors;
+import ch.ethz.idsc.tensor.qty.Quantity;
 import ch.ethz.idsc.tensor.qty.QuantityMagnitude;
 import ch.ethz.idsc.tensor.qty.QuantityUnit;
 import ch.ethz.idsc.tensor.qty.Unit;
@@ -45,17 +47,17 @@ public class ChassisGeometryTest extends TestCase {
   }
 
   public void testSteerAngleTowardsLeft() {
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(RealScalar.of(0.3));
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Quantity.of(0.3, SI.PER_METER));
     assertTrue(Chop._13.close(RealScalar.of(0.34289723785565446), angle));
   }
 
   public void testSteerAngleTowardsRight() {
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(RealScalar.of(-.2));
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Quantity.of(-.2, SI.PER_METER));
     assertTrue(Chop._13.close(RealScalar.of(-0.2336530501796457), angle));
   }
 
   public void testSteerAngleStraight() {
-    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(RealScalar.ZERO);
+    Scalar angle = ChassisGeometry.GLOBAL.steerAngleForTurningRatio(Quantity.of(0, SI.PER_METER));
     assertTrue(Chop._13.close(RealScalar.of(0), angle));
   }
 


### PR DESCRIPTION
These changes could be implemented more nicely by already providing ratios with units in `PurePursuit` and `GeodesicPursuit`.
However this needs to be done in `owl`.
**Issue:** `PurePursuit` and `GeodesicPursuit` might need to be able to handle different or no units in input.